### PR TITLE
Propose more relaxtions to closure catpures

### DIFF
--- a/lang-changes.md
+++ b/lang-changes.md
@@ -1,6 +1,6 @@
 # Language Changes
 
-This document lists changes that will be made to language along with RFC-2229.
+This document lists changes that will be made to the language along with RFC-2229.
 
 For this document let RS20 be the pre-RFC compiler and RS21 be the post-RFC compiler.
 

--- a/lang-changes.md
+++ b/lang-changes.md
@@ -7,6 +7,7 @@ For this document let RS20 be the pre-RFC compiler and RS21 be the post-RFC comp
 ## `_` pattern in closures
 
 Consider the following code 
+
 ```rust 
 let x;
 let c = || {
@@ -17,7 +18,8 @@ let c = || {
 RS20 will result in the capture of x within the closure, but `_` is just an ignore/discard and that means x can't/won't be used within the closure and should not result in a capture.
 
 For RS21 we propose to ignore such captures allowing the following code to be accepted by RS21
-```
+
+```rust
 let x;
 let c = || {
       let _ = x;

--- a/lang-changes.md
+++ b/lang-changes.md
@@ -28,4 +28,4 @@ let c = || {
 let f : fn() = c; 
 ```
 
-The above code works now because `x` isn't captured by `c` anymore making `c` a non-capturing closure, which can be coerced to a `FnPtr`
+The above code works now because `x` isn't captured by `c` anymore, making `c` a non-capturing closure, which can be coerced to a `FnPtr`.

--- a/lang-changes.md
+++ b/lang-changes.md
@@ -17,7 +17,7 @@ let c = || {
 
 RS20 will result in the capture of x within the closure, but `_` is just an ignore/discard and that means x can't/won't be used within the closure and should not result in a capture.
 
-For RS21 we propose to ignore such captures allowing the following code to be accepted by RS21
+For RS21 we propose to ignore such captures allowing the following pieces of code to be accepted by RS21
 
 ```rust
 let x;
@@ -26,6 +26,28 @@ let c = || {
 };
 
 let f : fn() = c; 
+
+f();
 ```
 
 The above code works now because `x` isn't captured by `c` anymore, making `c` a non-capturing closure, which can be coerced to a `FnPtr`.
+
+```rust
+fn main() {
+    let mut x = String::from("1");
+    
+    let c = || {
+        let _ = x;
+    };
+    
+    
+    let mx = &mut x;
+    *mx = String::from("2");
+    
+    c();
+    
+    println!("{}", x);
+}
+```
+RS20 would immutably borrow x within the closure (even thought it's discarded), preventing a mutable borrow to exist outside the closure. 
+The above code works with RS21 because `x` isn't captured within the closure allowing the mutable borrow outside the closure to exist.

--- a/lang-changes.md
+++ b/lang-changes.md
@@ -1,0 +1,29 @@
+# Language Changes
+
+This document lists changes that will be made to language along with RFC-2229.
+
+For this document let RS20 be the pre-RFC compiler and RS21 be the post-RFC compiler.
+
+## `_` pattern in closures
+
+Consider the following code 
+```rust 
+let x;
+let c = || {
+      let _ = x;
+}; 
+```
+
+RS20 will result in the capture of x within the closure, but `_` is just an ignore/discard and that means x can't/won't be used within the closure and should not result in a capture.
+
+For RS21 we propose to ignore such captures allowing the following code to be accepted by RS21
+```
+let x;
+let c = || {
+      let _ = x;
+};
+
+let f : fn() = c; 
+```
+
+The above code works now because `x` isn't captured by `c` anymore making `c` a non-capturing closure, which can be coerced to a `FnPtr`


### PR DESCRIPTION
Conceptually this is a result of capturing based on the use of variables from the enclosing environment of the closure instead of based on variables that appear within the closure.

Breif details about implementation:
- Instead of initializing `closure_captures`, `upvars_capture_map` and `ClosureSubsts` using `upvars_mentioned` we will rely on expressions/ Places being used within the closure. This will be handled as part of #7  #4
- For coercing a closure to FnPtr, instead of relying on `upvars_mentioned` in typechk we will accept such code in typechk while setting a no-capture obligation that will be validated in trait selection post capture analysis.

[Rendered](https://github.com/rust-lang/project-rfc-2229/blob/lang-changes.md-1/lang-changes.md)

cc: @rust-lang/wg-rfc-2229 